### PR TITLE
Don't leak all of ItsIt into main, just ItsIt::Kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.2.3
+
+before_install: gem install bundler -v ">= 1.10.0" --conservative

--- a/lib/its-it.rb
+++ b/lib/its-it.rb
@@ -4,5 +4,4 @@ require 'its-it/it'
 require 'its-it/kernel'
 require 'its-it/version'
 
-include ItsIt
 include ItsIt::Kernel

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -1,0 +1,11 @@
+require File.dirname(__FILE__) + "/spec_helper"
+
+describe Object do
+  it "doesn't get ItsIt's version" do
+    expect(defined?(::VERSION)).to be_nil
+  end
+
+  it "does't get the It class" do
+    expect(defined?(::It)).to be_nil
+  end
+end


### PR DESCRIPTION
Otherwise all objects take on ::VERSION from ItsIt unless they happen to override it.

Fixes https://github.com/SchemaPlus/schema_monkey/issues/9